### PR TITLE
Update bookmarking to align with new data collection format

### DIFF
--- a/jukeboxd-next/src/backend/users.js
+++ b/jukeboxd-next/src/backend/users.js
@@ -325,12 +325,16 @@ export const removeAlbumBookmark = async (user_id, album_id) => {
             throw new Error("User not found");
         }
 
+        const userData = userDoc.data();
+        const updatedBookmarks = (userData.bookmarkedAlbums || []).filter(album => album.album_id !== album_id);
+
         await updateDoc(userRef, {
-            bookmarkedAlbums: userDoc.data().bookmarkedAlbums.filter(id => id !== album_id)
+            bookmarkedAlbums: updatedBookmarks
         });
 
         return { message: "Album removed from bookmarks successfully" };
     } catch (error) {
         throw error;
     }
-}
+};
+

--- a/jukeboxd-next/src/backend/users.js
+++ b/jukeboxd-next/src/backend/users.js
@@ -277,15 +277,19 @@ export const removeSongBookmark = async (user_id, song_id) => {
             throw new Error("User not found");
         }
 
+        const userData = userDoc.data();
+        const updatedBookmarks = (userData.bookmarkedSongs || []).filter(song => song.song_id !== song_id);
+
         await updateDoc(userRef, {
-            bookmarkedSongs: userDoc.data().bookmarkedSongs.filter(id => id !== song_id)
+            bookmarkedSongs: updatedBookmarks
         });
 
         return { message: "Song removed from bookmarks successfully" };
     } catch (error) {
         throw error;
     }
-}
+};
+
 
 export const BookmarkAlbum = async (user_id, album_id, album_name, album_artist) => {
     try {

--- a/jukeboxd-next/src/pages/album-page/[id].js
+++ b/jukeboxd-next/src/pages/album-page/[id].js
@@ -77,7 +77,6 @@ const AlbumPage = () => {
   useEffect(() => {
       if (userData && Array.isArray(userData.bookmarkedAlbums) && albumId) {
           const isAlreadyBookmarked = userData.bookmarkedAlbums.some(album => {
-              console.log("Checking:", album.album_id.trim(), "vs", String(albumId).trim());
               return album.album_id.trim() === String(albumId).trim();
           });
 

--- a/jukeboxd-next/src/pages/album-page/[id].js
+++ b/jukeboxd-next/src/pages/album-page/[id].js
@@ -44,19 +44,48 @@ const AlbumPage = () => {
   const [userData, setUserData] = useState(null);
   const [selectedTab, setSelectedTab] = useState(0);
   useEffect(() => {
-    const fetchReviews = async () => {
-      try {
-        if (!user) return;
-        const data = await getUser(user.uid);
-        setIsBookmarked(data.bookmarkedAlbums?.includes(albumId) || false);
-        setUserData({ ...data, uid: user.uid });
-      } catch (err) {
-        console.error('Error fetching reviews:', err);
-        setError(err.message);
-      }
+    const fetchUserData = async () => {
+        try {
+            if (!user || !albumId) return; // Ensure user and albumId exist
+
+            const data = await getUser(user.uid);
+
+            if (data && Array.isArray(data.bookmarkedAlbums)) {
+                setUserData({ ...data, uid: user.uid });
+
+                // Check if album_id exists in bookmarkedAlbums
+                const isAlreadyBookmarked = data.bookmarkedAlbums.some(album => {
+                    return album.album_id.trim() === String(albumId).trim();
+                });
+
+                setIsBookmarked(prev => {
+                    return isAlreadyBookmarked;
+                });
+            } else {
+                setIsBookmarked(false);
+            }
+        } catch (err) {
+            console.error('Error fetching user data:', err);
+            setError(err.message);
+        }
     };
-    fetchReviews();
-  }, [albumId, user]);
+
+    fetchUserData();
+  }, [albumId, user]); // Ensure this runs on user or albumId changes
+
+  // Ensure isBookmarked updates if userData changes
+  useEffect(() => {
+      if (userData && Array.isArray(userData.bookmarkedAlbums) && albumId) {
+          const isAlreadyBookmarked = userData.bookmarkedAlbums.some(album => {
+              console.log("Checking:", album.album_id.trim(), "vs", String(albumId).trim());
+              return album.album_id.trim() === String(albumId).trim();
+          });
+
+          console.log("Updating isBookmarked to:", isAlreadyBookmarked);
+          setIsBookmarked(isAlreadyBookmarked);
+      }
+  }, [userData, albumId]);
+
 
   useEffect(() => {
       // Ensure albumId and token are present before making API calls

--- a/jukeboxd-next/src/pages/song-page/[id].js
+++ b/jukeboxd-next/src/pages/song-page/[id].js
@@ -48,22 +48,32 @@ const SongPage = () => {
     useEffect(() => {
         const fetchReviews = async () => {
             try {
-                if (!user) return;
+                if (!user || !songId) return;
+                
                 const data = await getUser(user.uid);
                 const reviews_data = await getReviews(songId, "song");
                 setReviews(reviews_data);
-                setIsBookmarked(
-                    data.bookmarkedSongs?.includes(songId) || false
-                );
+    
+                if (data && Array.isArray(data.bookmarkedSongs)) {
+                    // Check if any object in bookmarkedSongs matches songId
+                    const isAlreadyBookmarked = data.bookmarkedSongs.some(song => {
+                        return song.song_id.trim() === String(songId).trim();
+                    });
+                    setIsBookmarked(isAlreadyBookmarked);
+                } else {
+                    setIsBookmarked(false);
+                }
+    
                 setUserData({ ...data, uid: user.uid });
             } catch (err) {
                 console.error("Error fetching reviews:", err);
                 setError(err.message);
             }
         };
-
+    
         fetchReviews();
     }, [songId, user]);
+    
 
     // Fetch song data when songId is available
     useEffect(() => {


### PR DESCRIPTION
This PR resolves bookmarking issues where:
- Duplicate song/album entries could be added due to outdated API logic
- Bookmarks couldn't be removed properly as they referenced an old data format

Root cause: some APIs were still using the outdated isBookmarked format (an array of strings) instead of the new format (an array of objects where the first field represents the album ID)

Fixed...
- Updated APIs to align with the new bookmarking structure
- Ensured proper removal of bookmarks by referencing album/song objects correctly
- Prevented duplicate entries by checking for existing bookmarks before adding

This should fully sync bookmark functionality!!